### PR TITLE
remove wrong link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,9 +17,9 @@ language: en
 icons:
   rss: true
   email:
-  github: ttskch
+  github:
   bitbucket:
-  twitter: ttskch
+  twitter:
   facebook:
   google_plus:
   tumblr:


### PR DESCRIPTION
These two settings will cause the website link to incorrect places.
![image](https://user-images.githubusercontent.com/10943928/79889895-3c690180-8431-11ea-9e94-c624e5e3651c.png)
You can validate this by clicking icons on the right-hand side of the page.