### PR TITLE
Parameterize the output file in hisatgenotype_conc_results.py

### DIFF
--- a/hisatgenotype_tools/hisatgenotype_conc_results.py
+++ b/hisatgenotype_tools/hisatgenotype_conc_results.py
@@ -60,6 +60,10 @@ if __name__ == '__main__':
                         action = "store_true",
                         help='Save Results as CSV dataframe')
 
+    parser.add_argument("--output-file",
+                        default="HG_report_results.csv",
+                        help='Path to the output CSV file')
+
     args = parser.parse_args()
 
     if args.read_dir:
@@ -129,7 +133,7 @@ if __name__ == '__main__':
 
     if args.csv:
         scores.insert(0, genecol)
-        with open("HG_report_results.csv", "w") as ofo:
+        with open(args.output_file, "w") as ofo:
             for line in scores:
                 line = "\t".join(line)
                 ofo.write(line + "\n")


### PR DESCRIPTION
As per the discussion in #16, this PR adds an `--output-file` argument to the `hisatgenotype_conc_results.py` script to allow you to specify an output CSV file. 