### PR TITLE
Fix setup.sh script and add check for samtools in PATH

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -71,8 +71,6 @@ fi
 
 ## This section downloads and sets-up hisat2 submodule
 echo "Setting up HISAT2"
-# Move to hisat2 submodule directory
-cd hisat2
 
 if ! command -v hisat2 &> /dev/null; then
     if test ! -f "$BUILT"; then
@@ -83,10 +81,12 @@ if ! command -v hisat2 &> /dev/null; then
             git submodule update
         fi
         echo "> Initiating Build"
+        # Move to hisat2 submodule directory
+        cd hisat2
         make
+        cd ../
     fi
 fi
-cd ../
 
 # Add PATH lines to BASH
 if [ "$OMMIT_BASH" == "NO" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -62,6 +62,13 @@ BUILT="hisat2-align-l"
 BASHRC=~/.bashrc
 BASH_PROFILE=~/.bash_profile
 
+# Exit code for `type -P` is 1 if samtools cannot be found in PATH
+type -P samtools &> /dev/null
+if [[ $? == 1 ]]; then
+    echo "Could not find samtools in PATH"
+    exit 1;
+fi
+
 ## This section downloads and sets-up hisat2 submodule
 echo "Setting up HISAT2"
 # Move to hisat2 submodule directory


### PR DESCRIPTION
This PR 

* Fixes a bug in the `setup.sh` script where it doesn't update the hisat2 submodule and build it:
    + To commands `git submodule init; git submodule update` need to run from the root directory of the repository. The current `setup.sh` script changes to the `hisat2` folder and then tries to run these commands throwing an error, which doesn't get caught by the script. 
* Adds a small check for whether `samtools` is in the PATH or not and throws an error if not. 