### PR TITLE
Add core_fid as an input parameter

### DIFF
--- a/hisatgenotype
+++ b/hisatgenotype
@@ -606,6 +606,7 @@ def typing_process(args):
                              args.verbose_level,
                              args.assembly_verbose,
                              args.out_dir,
+                             args.core_fid,
                              debug)
     else:
         log = {} # build log to capture errors
@@ -659,6 +660,7 @@ def typing_process(args):
                             args.verbose_level,
                             args.assembly_verbose,
                             args.out_dir,
+                            args.core_fid,
                             debug)
                     )
 

--- a/hisatgenotype_modules/hisatgenotype_args.py
+++ b/hisatgenotype_modules/hisatgenotype_args.py
@@ -43,6 +43,11 @@ def args_common(parser,
                         dest='verbose',
                         action='store_true',
                         help='Print statistics to stderr')
+    parser.add_argument("--core-fid",
+                        dest="core_fid",
+                        type=str,
+                        default=None,
+                        help="Core file id serves as the output file prefix")
     if debug:
         parser.add_argument("--debug",
                             dest="debug",

--- a/hisatgenotype_modules/hisatgenotype_typing_core.py
+++ b/hisatgenotype_modules/hisatgenotype_typing_core.py
@@ -282,19 +282,19 @@ def typing(simulation,
            assembly_verbose,
            out_dir,
            dbversion,
-           test_i = 0):
+           core_fid=None,
+           test_i=0):
 
     complete     = {"Init Align"    : False,
                     "Locus Process" : False,
                     "Align Return"  : False} # list of completed tasks
     base_fname  = full_path_base_fname.split("/")[-1]
-    core_fid    = "" # May add to bottom of options
     report_base = '%s/%s-%s.' % (out_dir, output_base, base_fname)
     if simulation:
         test_passed  = {}
         core_fid     = str(test_i + 1)
         report_base += "test-"
-    else:
+    elif not core_fid:
         core_fid = '_'.join(read_fname[0].split('/')[-1].split('.')[:-1])
 
     report_base += core_fid
@@ -2304,6 +2304,7 @@ def genotyping_locus(base_fname,
                      verbose,
                      assembly_verbose,
                      out_dir,
+                     core_fid,
                      debug_instr):
     assert isinstance(base_fname, basestring)
     assert not ',' in base_fname
@@ -2393,9 +2394,7 @@ def genotyping_locus(base_fname,
     else:
         full_gg_path = ix_dir + "/" + base_fname
 
-        # Download human genome and HISAT2 index
         typing_common.clone_hisatgenotype_database(ix_dir)
-        typing_common.download_genome_and_index(ix_dir)  
 
         typing_common.extract_database_if_not_exists(base_fname,
                                                      only_locus_list,
@@ -2613,6 +2612,7 @@ def genotyping_locus(base_fname,
                                      assembly_verbose,
                                      out_dir,
                                      dbversion,
+                                     core_fid,
                                      test_i)
 
             didpass = False
@@ -2684,4 +2684,5 @@ def genotyping_locus(base_fname,
                verbose,
                assembly_verbose,
                out_dir,
-               dbversion)
+               dbversion,
+               core_fid)


### PR DESCRIPTION
Currently the output filename follows this format: `${out_dir}/${output_base}-${base_fname}.${core_fid}`.report where core_fid is extracted from `read_fname[0`]. To make the output filename simpler, a `core_fid` option was added so the specified output filename can be consistent regardless of inputs.