### PR TITLE
Remove genome db dependency in genotyping locus function

### DIFF
--- a/hisatgenotype_modules/hisatgenotype_typing_core.py
+++ b/hisatgenotype_modules/hisatgenotype_typing_core.py
@@ -2393,9 +2393,7 @@ def genotyping_locus(base_fname,
     else:
         full_gg_path = ix_dir + "/" + base_fname
 
-        # Download human genome and HISAT2 index
         typing_common.clone_hisatgenotype_database(ix_dir)
-        typing_common.download_genome_and_index(ix_dir)  
 
         typing_common.extract_database_if_not_exists(base_fname,
                                                      only_locus_list,


### PR DESCRIPTION
AFAIK, the genome file along with its indexes are not needed during the genotyping step. Since we package `hisat-genotype` in a docker image using pre-built indexes, I'd like to keep the image as small as possible/avoid downloading these genome files every single time we launch a new instance. I've tested out the code using different use cases and removing that line seems to have no effects. Please let me know if there're other use cases that I haven't considered! Thanks again!